### PR TITLE
fix: default registry should be set to NPM_REGISTRY_URL

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,10 @@ set -e
 if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
+  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
 
   # Allow registry.npmjs.org to be overridden with an environment variable
-  echo "//${NPM_REGISTRY_URL-registry.npmjs.org}/:_authToken=$NPM_AUTH_TOKEN" > "$NPM_CONFIG_USERCONFIG"
+  printf "//$NPM_REGISTRY_URL/:_authToken=$NPM_AUTH_TOKEN\nregistry=$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 


### PR DESCRIPTION
If someone sets an alternate `NPM_REGISTRY_URL` I believe the expected behavior is that installations/publications will route to this URL. Setting:

`//$NPM_REGISTRY_URL/:_authToken=$NPM_AUTH_TOKEN`

alone populates the credentials for `NPM_REGISTRY_URL`, but will continue routing requests to `registry.npmjs.org`. I think it would be better to set:

```
`//$NPM_REGISTRY_URL/:_authToken=$NPM_AUTH_TOKEN`
`registry=$NPM_REGISTRY_URL`
```