### PR TITLE
Update example to only publish for a "tag push"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,15 @@ action "Test" {
   args = "test"
 }
 
-action "Publish" {
+# Filter for a new tag
+action "Tag" {
   needs = "Test"
+  uses = "actions/bin/filter@master"
+  args = "tag"
+}
+
+action "Publish" {
+  needs = "Tag"
   uses = "actions/npm@master"
   args = "publish --access public"
   secrets = ["NPM_AUTH_TOKEN"]


### PR DESCRIPTION
Updates the `README` example to only publish to npm for a tag ref, using [the filter ](https://github.com/actions/bin/tree/master/filter) action.

Following this example, to publish a new release, a new tag will first need to be created and pushed.

Fixes #1.