### PR TITLE
Fix non-default registry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,19 @@ action "Publish" {
 
 ### Environment variables
 
-* `NPM_REGISTRY_URL` - **Optional**. To specify a registry to authenticate with. Defaults to `registry.npmjs.org`
+* `NPM_REGISTRY_URL` - **Optional**. To specify a registry to authenticate with. Defaults to `https://registry.npmjs.org`
 * `NPM_CONFIG_USERCONFIG` - **Optional**. To specify a non-default per-user configuration file. Defaults to `$HOME/.npmrc` ([more info](https://docs.npmjs.com/misc/config#npmrc-files))
 
 #### Example
 
-To authenticate with, and publish to, a registry other than `registry.npmjs.org`:
+To authenticate with, and publish to, a registry other than `https://registry.npmjs.org`:
 
 ```hcl
 action "Publish" {
   uses = "actions/npm@master"
   args = "publish --access public"
   env = {
-    NPM_REGISTRY_URL = "someOtherRegistry.someDomain.net"
+    NPM_REGISTRY_URL = "https://someOtherRegistry.someDomain.net"
   }
   secrets = ["NPM_AUTH_TOKEN"]
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,10 +5,11 @@ set -e
 if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
-  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
+  NPM_REGISTRY_URL="${NPM_REGISTRY_URL-https://registry.npmjs.org}"
+  NPM_REGISTRY_HOST=`echo $NPM_REGISTRY_URL | sed 's/https\?:\/\///'`
 
   # Allow registry.npmjs.org to be overridden with an environment variable
-  printf "//$NPM_REGISTRY_URL/:_authToken=$NPM_AUTH_TOKEN\nregistry=$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
+  printf "//$NPM_REGISTRY_HOST/:_authToken=$NPM_AUTH_TOKEN\nregistry=$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -18,14 +18,18 @@ function setup() {
   export NPM_AUTH_TOKEN=NPM_AUTH_TOKEN
   run $GITHUB_WORKSPACE/entrypoint.sh help
   [ "$status" -eq 0 ]
-  [ "$(cat $NPM_CONFIG_USERCONFIG)" = "//registry.npmjs.org/:_authToken=NPM_AUTH_TOKEN" ]
+  run cat $NPM_CONFIG_USERCONFIG
+  [ "${lines[0]}" = "//registry.npmjs.org/:_authToken=NPM_AUTH_TOKEN" ]
+  [ "${lines[1]}" = "registry=https://registry.npmjs.org" ]
 }
 
 @test "registry can be overridden" {
   export NPM_CONFIG_USERCONFIG=$( mktemp )
-  export NPM_REGISTRY_URL=someOtherRegistry.someDomain.net
+  export NPM_REGISTRY_URL=https://someOtherRegistry.someDomain.net
   export NPM_AUTH_TOKEN=NPM_AUTH_TOKEN
   run $GITHUB_WORKSPACE/entrypoint.sh help
   [ "$status" -eq 0 ]
-  [ "$(cat $NPM_CONFIG_USERCONFIG)" = "//someOtherRegistry.someDomain.net/:_authToken=NPM_AUTH_TOKEN" ]
+  run cat $NPM_CONFIG_USERCONFIG
+  [ "${lines[0]}" = "//someOtherRegistry.someDomain.net/:_authToken=NPM_AUTH_TOKEN" ]
+  [ "${lines[1]}" = "registry=https://someOtherRegistry.someDomain.net" ]
 }


### PR DESCRIPTION
Fixes #10 
- Switch to using full url for `$NPM_REGISTRY_URL` (with support for http and https)
- updated docs
- updated test to reflect the changes