### PR TITLE
Fix entrypoint tests and observe shell linting rules

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -13,13 +13,18 @@ action "Test" {
   args = "test/*.bats"
 }
 
+action "Integration Test" {
+  uses = "./"
+  args = "version"
+}
+
 action "Docker Lint" {
   uses = "docker://replicated/dockerfilelint"
   args = ["Dockerfile"]
 }
 
 action "Build" {
-  needs = ["Shell Lint", "Test", "Docker Lint"]
+  needs = ["Shell Lint", "Test", "Integration Test", "Docker Lint"]
   uses = "actions/docker/cli@master"
   args = "build -t npm ."
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
   NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
 
   # Allow registry.npmjs.org to be overridden with an environment variable
-  printf "//$NPM_REGISTRY_URL/:_authToken=$NPM_AUTH_TOKEN\nregistry=$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
+  printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -18,7 +18,9 @@ function setup() {
   export NPM_AUTH_TOKEN=NPM_AUTH_TOKEN
   run $GITHUB_WORKSPACE/entrypoint.sh help
   [ "$status" -eq 0 ]
-  [ "$(cat $NPM_CONFIG_USERCONFIG)" = "//registry.npmjs.org/:_authToken=NPM_AUTH_TOKEN" ]
+  run cat $NPM_CONFIG_USERCONFIG
+  [ "${lines[0]}" = "//registry.npmjs.org/:_authToken=NPM_AUTH_TOKEN" ]
+  [ "${lines[1]}" = "registry=registry.npmjs.org" ]
 }
 
 @test "registry can be overridden" {
@@ -27,5 +29,7 @@ function setup() {
   export NPM_AUTH_TOKEN=NPM_AUTH_TOKEN
   run $GITHUB_WORKSPACE/entrypoint.sh help
   [ "$status" -eq 0 ]
-  [ "$(cat $NPM_CONFIG_USERCONFIG)" = "//someOtherRegistry.someDomain.net/:_authToken=NPM_AUTH_TOKEN" ]
+  run cat $NPM_CONFIG_USERCONFIG
+  [ "${lines[0]}" = "//someOtherRegistry.someDomain.net/:_authToken=NPM_AUTH_TOKEN" ]
+  [ "${lines[1]}" = "registry=someOtherRegistry.someDomain.net" ]
 }


### PR DESCRIPTION
I was reviewing https://github.com/actions/npm/pull/11 and realised the tests were failing on master, so I pulled out the test fixes into this PR so I can review https://github.com/actions/npm/pull/11 more easily.

I also noticed we were failing the shell linting rules so went ahead and addressed those:
```
In entrypoint.sh line 11:
  printf "//$NPM_REGISTRY_URL/:_authToken=$NPM_AUTH_TOKEN\nregistry=$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
         ^-- SC2059: Don't use variables in the printf format string. Use printf "..%s.." "$foo".
                                                         ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".

```

Finally I added an integration test to the workflow because the build step there isn't guaranteed to actually match what actions does, so it's a good idea to sanity check that the action can be used.