### PR TITLE
Adds support for the NPM_STRICT_SSL environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,12 @@ action "Publish" {
 ### Environment variables
 
 * `NPM_REGISTRY_URL` - **Optional**. To specify a registry to authenticate with. Defaults to `registry.npmjs.org`
+* `NPM_STRICT_SSL` - **Optional**. Specify false if your registry is insecure and uses the `http` protocol. Defaults to `true`
 * `NPM_CONFIG_USERCONFIG` - **Optional**. To specify a non-default per-user configuration file. Defaults to `$HOME/.npmrc` ([more info](https://docs.npmjs.com/misc/config#npmrc-files))
 
 #### Example
 
-To authenticate with, and publish to, a registry other than `registry.npmjs.org`:
+To authenticate with, and publish to, a secure registry other than `registry.npmjs.org`:
 
 ```hcl
 action "Publish" {
@@ -62,6 +63,20 @@ action "Publish" {
 }
 ```
 
+
+To authenticate with, and publish to, an insecure registry other than `registry.npmjs.org`:
+
+```hcl
+action "Publish" {
+  uses = "actions/npm@master"
+  args = "publish --access public"
+  env = {
+    NPM_REGISTRY_URL = "my.local.registry"
+    NPM_STRICT_SSL = "false"
+  }
+  secrets = ["NPM_AUTH_TOKEN"]
+}
+```
 ## License
 
 The Dockerfile and associated scripts and documentation in this project are released under the [MIT License](LICENSE).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,9 +6,16 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Respect NPM_CONFIG_USERCONFIG if it is provided, default to $HOME/.npmrc
   NPM_CONFIG_USERCONFIG="${NPM_CONFIG_USERCONFIG-"$HOME/.npmrc"}"
   NPM_REGISTRY_URL="${NPM_REGISTRY_URL-registry.npmjs.org}"
+  NPM_STRICT_SSL="${NPM_STRICT_SSL-true}"
+  NPM_REGISTRY_SCHEME="https"
+  if ! $NPM_STRICT_SSL
+  then
+	NPM_REGISTRY_SCHEME="http"
+  fi
 
   # Allow registry.npmjs.org to be overridden with an environment variable
-  printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
+  printf "//%s/:_authToken=%s\\nregistry=%s\\nstrict-ssl=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "${NPM_REGISTRY_SCHEME}://$NPM_REGISTRY_URL" "${NPM_STRICT_SSL}" > "$NPM_CONFIG_USERCONFIG"
+
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
   NPM_REGISTRY_SCHEME="https"
   if ! $NPM_STRICT_SSL
   then
-	NPM_REGISTRY_SCHEME="http"
+    NPM_REGISTRY_SCHEME="http"
   fi
 
   # Allow registry.npmjs.org to be overridden with an environment variable

--- a/test/entrypoint.bats
+++ b/test/entrypoint.bats
@@ -20,7 +20,7 @@ function setup() {
   [ "$status" -eq 0 ]
   run cat $NPM_CONFIG_USERCONFIG
   [ "${lines[0]}" = "//registry.npmjs.org/:_authToken=NPM_AUTH_TOKEN" ]
-  [ "${lines[1]}" = "registry=registry.npmjs.org" ]
+  [ "${lines[1]}" = "registry=https://registry.npmjs.org" ]
 }
 
 @test "registry can be overridden" {
@@ -31,5 +31,18 @@ function setup() {
   [ "$status" -eq 0 ]
   run cat $NPM_CONFIG_USERCONFIG
   [ "${lines[0]}" = "//someOtherRegistry.someDomain.net/:_authToken=NPM_AUTH_TOKEN" ]
-  [ "${lines[1]}" = "registry=someOtherRegistry.someDomain.net" ]
+  [ "${lines[1]}" = "registry=https://someOtherRegistry.someDomain.net" ]
+}
+
+@test "supports insecure registry" {
+  export NPM_CONFIG_USERCONFIG=$( mktemp )
+  export NPM_STRICT_SSL=false
+  export NPM_REGISTRY_URL=someOtherRegistry.someDomain.net
+  export NPM_AUTH_TOKEN=NPM_AUTH_TOKEN
+  run $GITHUB_WORKSPACE/entrypoint.sh help
+  [ "$status" -eq 0 ]
+  run cat $NPM_CONFIG_USERCONFIG
+  [ "${lines[0]}" = "//someOtherRegistry.someDomain.net/:_authToken=NPM_AUTH_TOKEN" ]
+  [ "${lines[1]}" = "registry=http://someOtherRegistry.someDomain.net" ]
+  [ "${lines[2]}" = "strict-ssl=false" ]
 }


### PR DESCRIPTION
Fixes: https://github.com/actions/npm/issues/10
This is an alternate approach to better support insecure npm registries in the Action.
This PR introduces a `NPM_STRICT_SSL` variable that allows a caller to set the [strict-ssl](https://docs.npmjs.com/misc/config#strict-ssl) configuration in the `.npmrc` file on the container. Using this setting, one can configure their action to talk to an insecure npm registry.

Here's an example of a `.npmrc` file generated by the action by setting `NPM_STRICT_SSL` to false
``` bash
//someOtherRegistry.someDomain.net/:_authToken=NPM_AUTH_TOKEN
registry=http://someOtherRegistry.someDomain.net
strict-ssl=false
```